### PR TITLE
Update structurizr's nuget packages and apply corresponding fixes to code

### DIFF
--- a/Structurizr/App.config
+++ b/Structurizr/App.config
@@ -23,7 +23,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-8.0.0.0" newVersion="8.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.0" newVersion="10.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Collections.Immutable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />

--- a/Structurizr/Structurizr.cs
+++ b/Structurizr/Structurizr.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using Structurizr.Analysis;
-using Structurizr.Client;
 using System.Linq;
+using Structurizr.Api;
 
 namespace Structurizr
 {
@@ -35,7 +35,7 @@ namespace Structurizr
             ComponentFinder componentFinder = new ComponentFinder(
                 webApplication,
                 typeof(ContosoUniversity.MvcApplication).Namespace, // doing this typeof forces the ContosoUniversity assembly to be loaded
-                new TypeBasedComponentFinderStrategy(
+                new TypeMatcherComponentFinderStrategy(
                     new InterfaceImplementationTypeMatcher(typeof(System.Web.Mvc.IController), null, "ASP.NET MVC Controller"),
                     new ExtendsClassTypeMatcher(typeof(System.Data.Entity.DbContext), null, "Entity Framework DbContext")
                 )
@@ -52,7 +52,7 @@ namespace Structurizr
             // link the components to the source code
             foreach (Component component in webApplication.Components)
             {
-                foreach (CodeElement codeElement in component.Code)
+                foreach (CodeElement codeElement in component.CodeElements)
                 {
                     if (codeElement.Url != null)
                     {
@@ -91,7 +91,7 @@ namespace Structurizr
             styles.Add(new ElementStyle(Tags.Component) { Background = "#407f7f", Color = "#ffffff" });
 
             StructurizrClient structurizrClient = new StructurizrClient("key", "secret");
-            structurizrClient.MergeWorkspace(5651, workspace);
+//            structurizrClient.MergeWorkspace(5651, workspace);
         }
     }
 }

--- a/Structurizr/Structurizr.csproj
+++ b/Structurizr/Structurizr.csproj
@@ -51,16 +51,18 @@
       <HintPath>..\packages\EntityFramework.6.1.3\lib\net45\EntityFramework.SqlServer.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=8.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.8.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.10.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
-    <Reference Include="Structurizr.Core, Version=0.4.0.1, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Structurizr.Core.0.4.0.1\lib\net40\Structurizr.Core.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Structurizr.Core, Version=0.6.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Structurizr.Core.0.6.0\lib\net45\Structurizr.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="Structurizr.Reflection, Version=0.6.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Structurizr.Reflection.0.6.0\lib\net452\Structurizr.Reflection.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.DataAnnotations" />
+    <Reference Include="System.Net.Http" />
     <Reference Include="System.Web" />
     <Reference Include="System.Web.Mvc, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.AspNet.Mvc.5.2.3\lib\net45\System.Web.Mvc.dll</HintPath>

--- a/Structurizr/packages.config
+++ b/Structurizr/packages.config
@@ -5,6 +5,8 @@
   <package id="Microsoft.AspNet.Razor" version="3.2.3" targetFramework="net452" />
   <package id="Microsoft.AspNet.WebPages" version="3.2.3" targetFramework="net452" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net452" />
-  <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net452" />
-  <package id="Structurizr.Core" version="0.4.0.1" targetFramework="net452" />
+  <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net452" />
+  <package id="Structurizr.Core" version="0.6.0" targetFramework="net452" />
+  <package id="Structurizr.Reflection" version="0.6.0" targetFramework="net452" />
+  <package id="System.Net.Http" version="4.3.3" targetFramework="net452" />
 </packages>


### PR DESCRIPTION
The Contoso University example was (still) using an old version of structurizr. 
I updated the project to make use of the most recent versions:
* Structurizr.core 0.6.0
* Structurizr.reflection 0.6.0

This update required a few changes to Structurizr.cs. 
**The only thing I couldn't figure out is the call to MergeWorkspace in the last line of Structurizr.cs** Can you have a look it that one before merging?